### PR TITLE
add parameters to manage opn-cli CA file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   * [Install and enable opnsense](#install-and-enable-opnsense)
   * [Configure OPNsense firewall(s)](#configure-opnsense-firewall-s-)
   * [Configure a client to export firewall aliases and rules](#configure-a-client-to-export-firewall-aliases-and-rules)
+  * [Dealing with self-signed certificates](#dealing-with-self-signed-certificates)
   * [More examples](#more-examples)
 - [Reference](#reference)
 - [Limitations](#limitations)
@@ -198,6 +199,23 @@ class { 'opnsense::client::firewall':
   }
 }
 ```
+
+### Dealing with self-signed certificates
+When connecting to the OPNsense API, this module will tell opn-cli to use the system-wide installed CA certificates to verify the SSL connection. However, this will only work when using a valid certificate for the OPNsense WebUI.
+
+If the OPNsense WebUI still uses the pre-installed self-signed certificate, then it is possible to use the OPNsense CA certificate for SSL verification:
+
+```
+class { 'opnsense':
+  use_system_ca => false,
+  ca_file       => '/root/.opn-cli/ca.pem',
+  ca_content    => '-----BEGIN CERTIFICATE-----
+AAAAAABBBBBBBBBCCCCCCCCCCDDDDDDDDDDDEEEEEEEEEEEFFFFFFFFFGGGGGGGG
+-----END CERTIFICATE-----'
+}
+```
+
+The OPNsense CA certificate can be downloaded from `System: Trust: Authorities` on the OPNsense firewall.
 
 ### More examples
 You find more examples in the [examples](examples) folder.

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -6,5 +6,10 @@ opnsense::api_manager_prefix: "%{fqdn} api manager - "
 opnsense::required_plugins:
   "os-firewall": {}
 opnsense::manage_resources: false
+opnsense::manage_ca: true
+opnsense::ca_content: ~
+opnsense::ca_file: '/root/.opn-cli/ca.pem'
+opnsense::use_system_ca: true
+opnsense::opncli_configdir: '/root/.opn-cli'
 opnsense::client::firewall::aliases: {}
 opnsense::client::firewall::rules: {}

--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -1,0 +1,2 @@
+---
+opnsense::system_ca_file: '/etc/ssl/certs/ca-certificates.crt'

--- a/data/os/FreeBSD.yaml
+++ b/data/os/FreeBSD.yaml
@@ -1,0 +1,2 @@
+---
+opnsense::system_ca_file: '/etc/ssl/cert.pem'

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,0 +1,2 @@
+---
+opnsense::system_ca_file: '/etc/pki/tls/certs/ca-bundle.crt'

--- a/spec/classes/opnsense_spec.rb
+++ b/spec/classes/opnsense_spec.rb
@@ -57,6 +57,47 @@ describe 'opnsense' do
                    )
         }
       end
+
+      describe 'with default CA settings' do
+        it { is_expected.to contain_file('Symlink opn-cli CA file to system-wide CA certificates').with_ensure('link') }
+        it { is_expected.to contain_file('Create opn-cli config directory').with_ensure('directory') }
+
+        it { is_expected.not_to contain_file('Create opn-cli CA file with custom CA content') }
+      end
+
+      describe 'with custom CA settings' do
+        let(:params) do
+          {
+            use_system_ca: false,
+            ca_content: '-----BEGIN CERTIFICATE-----
+AAAAAABBBBBBBBBCCCCCCCCCCDDDDDDDDDDDEEEEEEEEEEEFFFFFFFFFGGGGGGGG
+-----END CERTIFICATE-----',
+          }
+        end
+
+        describe 'compiles the catalog' do
+          it { is_expected.to compile.with_all_deps }
+        end
+
+        describe 'can manage the CA file' do
+          it { is_expected.to contain_file('Create opn-cli CA file with custom CA content').with_ensure('file') }
+          it { is_expected.to contain_file('Create opn-cli CA file with custom CA content').with_content(%r{.*AAAAAABBBBBBBBBCCCCCCCCCCDDDDDDDDDDDEEEEEEEEEEEFFFFFFFFFGGGGGGGG.*}) }
+
+          it { is_expected.not_to contain_file('Symlink opn-cli CA file to system-wide CA certificates') }
+        end
+      end
+
+      describe 'with CA settings disabled' do
+        let(:params) do
+          {
+            manage_ca: false,
+          }
+        end
+
+        it { is_expected.not_to contain_file('Create opn-cli config directory') }
+        it { is_expected.not_to contain_file('Symlink opn-cli CA file to system-wide CA certificates') }
+        it { is_expected.not_to contain_file('Create opn-cli CA file with custom CA content') }
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds the following:
* create the opn-cli config directory
* either symlink opn-cli ca file to system-wide ca file
* or create opn-cli ca file with custom content
* parameters to enable/disable every aspect of this functionality
* unit tests
* a new entry in README