### PR TITLE
change data type + default value of updatefreq to Numeric

### DIFF
--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
 
   Acceptance:
-    name: "OPNsense 21.7.4, CentOS-8, puppet7"
+    name: "OPNsense 21.7.4, Rocky-8, puppet7"
     runs-on: macOS-10.15
     strategy:
       fail-fast: false

--- a/lib/puppet/provider/opnsense_firewall_alias/opnsense_firewall_alias.rb
+++ b/lib/puppet/provider/opnsense_firewall_alias/opnsense_firewall_alias.rb
@@ -24,7 +24,7 @@ class Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias < Puppet::P
       description: json_list_item['description'],
       content: json_list_item['content'].split(','),
       proto: json_list_item['proto'],
-      updatefreq: json_list_item['updatefreq'].empty? ? '' : json_list_item['updatefreq'].to_f,
+      updatefreq: json_list_item['updatefreq'].nil? ? '' : json_list_item['updatefreq'].to_f,
       counters: bool_from_value(json_list_item['counters']),
       enabled: bool_from_value(json_list_item['enabled']),
       ensure: 'present',

--- a/lib/puppet/type/opnsense_firewall_alias.rb
+++ b/lib/puppet/type/opnsense_firewall_alias.rb
@@ -150,9 +150,9 @@ EOS
       default: ''
     },
     updatefreq: {
-      type: 'Variant[Enum[""], Float]',
+      type: 'Variant[Enum[""], Numeric]',
       desc: 'How often should the alias be updated in days.',
-      default: ''
+      default: 0
     },
     counters: {
       type: 'Optional[Variant[Enum[""], Boolean]]',

--- a/provision.yaml
+++ b/provision.yaml
@@ -1,14 +1,9 @@
 ---
 default:
   provisioner: docker_exp
-  images: [ 'litmusimage/centos:8' ]
+  images: [ 'litmusimage/rockylinux:8' ]
 acceptance:
   provisioner: docker_exp
-  images: [ 'litmusimage/centos:8' ]
+  images: [ 'litmusimage/rockylinux:8' ]
 opnsense:
   provisioner: vagrant
-
-
-
-
-

--- a/spec/unit/puppet/provider/opnsense_firewall_alias/opnsense_firewall_alias_spec.rb
+++ b/spec/unit/puppet/provider/opnsense_firewall_alias/opnsense_firewall_alias_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
           "type": 'host',
           "proto": '',
           "counters": '1',
-          "updatefreq": '',
+          "updatefreq": 0,
           "content": '10.0.0.1,!10.0.0.5',
           "description": 'Some hosts',
           "uuid": 'b6ae4857-8414-4440-acce-c09e4ae899fa'
@@ -30,7 +30,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
           "type": 'network',
           "proto": '',
           "counters": '1',
-          "updatefreq": '',
+          "updatefreq": 0,
           "content": '192.168.1.0/24,!192.168.1.128/25',
           "description": 'Some networks',
           "uuid": 'a6ae4857-8414-5550-acce-c09e4ae899fa'
@@ -41,7 +41,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
           "type": 'port',
           "proto": '',
           "counters": '',
-          "updatefreq": '',
+          "updatefreq": 0,
           "content": '80,443',
           "description": 'Some ports',
           "uuid": 'd6ae1257-8414-4440-acce-c09e4ae899fb'
@@ -52,7 +52,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
           "type": 'url',
           "proto": '',
           "counters": '1',
-          "updatefreq": '',
+          "updatefreq": 0,
           "content": 'https://www.spamhaus.org/drop/drop.txt,https://www.spamhaus.org/drop/edrop.txt',
           "description": 'spamhaus fetched once.',
           "uuid": 'b6ae4857-8414-4440-acce-c09e4ae899fd'
@@ -63,7 +63,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
           "type": 'urltable',
           "proto": 'IPv4,IPv6',
           "counters": '0',
-          "updatefreq": '0.5',
+          "updatefreq": 0.5,
           "content": 'https://www.spamhaus.org/drop/drop.txt,https://www.spamhaus.org/drop/edrop.txt',
           "description": 'Spamhaus block list',
           "uuid": 'ad51e4ea-ee3f-49dc-a662-1f8f88b5f18a'
@@ -74,7 +74,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
           "type": 'geoip',
           "proto": 'IPv4,IPv6',
           "counters": '1',
-          "updatefreq": '',
+          "updatefreq": 0,
           "content": 'DE,GR',
           "description": 'Only german and greek',
           "uuid": '5d385340-5d56-432d-8bd1-77267c122ede'
@@ -85,7 +85,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
           "type": 'networkgroup',
           "proto": '',
           "counters": '0',
-          "updatefreq": '',
+          "updatefreq": 0,
           "content": 'hosts_alias,network_alias',
           "description": 'Combine different network aliases into one',
           "uuid": 'bd51e4ea-ee3f-49dc-a662-1f8f88b5f11f'
@@ -96,7 +96,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
           "type": 'mac',
           "proto": '',
           "counters": '0',
-          "updatefreq": '',
+          "updatefreq": 0,
           "content": 'f4:90:ea,0c:4d:e9:b1:05:f0',
           "description": 'MAC address or partial mac addresses',
           "uuid": 'cd41e4ea-ee3f-49dc-a662-1f8f88b5f22a'
@@ -107,7 +107,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
           "type": 'external',
           "proto": 'IPv4',
           "counters": '1',
-          "updatefreq": '',
+          "updatefreq": 0,
           "content": '',
           "description": 'Externally managed',
           "uuid": 'dd22e4ea-ee3f-49dc-a662-1f8f88b5f33b'
@@ -122,7 +122,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
           "type": 'external',
           "proto": '',
           "counters": '',
-          "updatefreq": '',
+          "updatefreq": 0,
           "content": '',
           "description": 'bogon networks (internal)',
           "uuid": 'bogons'
@@ -133,7 +133,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
           "type": 'external',
           "proto": '',
           "counters": '',
-          "updatefreq": '',
+          "updatefreq": 0,
           "content": '',
           "description": 'bogon networks IPv6 (internal)',
           "uuid": 'bogonsv6'
@@ -144,7 +144,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
           "type": 'external',
           "proto": '',
           "counters": '',
-          "updatefreq": '',
+          "updatefreq": 0,
           "content": '',
           "description": 'abuse lockout table (internal)',
           "uuid": 'sshlockout'
@@ -155,7 +155,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
           "type": 'external',
           "proto": '',
           "counters": '',
-          "updatefreq": '',
+          "updatefreq": 0,
           "content": '',
           "description": 'overload table for rate limitting (internal)',
           "uuid": 'virusprot'
@@ -192,7 +192,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
               description: 'Some hosts',
               content: ['10.0.0.1', '!10.0.0.5'],
               proto: '',
-              updatefreq: '',
+              updatefreq: 0,
               counters: true,
               enabled: true,
               ensure: 'present'
@@ -205,7 +205,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
               description: 'Some networks',
               content: ['192.168.1.0/24', '!192.168.1.128/25'],
               proto: '',
-              updatefreq: '',
+              updatefreq: 0,
               counters: true,
               enabled: true,
               ensure: 'present'
@@ -218,7 +218,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
               description: 'Some ports',
               content: ['80', '443'],
               proto: '',
-              updatefreq: '',
+              updatefreq: 0,
               counters: false,
               enabled: true,
               ensure: 'present'
@@ -231,7 +231,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
               description: 'spamhaus fetched once.',
               content: ['https://www.spamhaus.org/drop/drop.txt', 'https://www.spamhaus.org/drop/edrop.txt'],
               proto: '',
-              updatefreq: '',
+              updatefreq: 0,
               counters: true,
               enabled: false,
               ensure: 'present'
@@ -257,7 +257,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
               description: 'Only german and greek',
               content: ['DE', 'GR'],
               proto: 'IPv4,IPv6',
-              updatefreq: '',
+              updatefreq: 0,
               counters: true,
               enabled: true,
               ensure: 'present'
@@ -270,7 +270,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
               description: 'Combine different network aliases into one',
               content: ['hosts_alias', 'network_alias'],
               proto: '',
-              updatefreq: '',
+              updatefreq: 0,
               counters: false,
               enabled: true,
               ensure: 'present'
@@ -283,7 +283,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
               description: 'MAC address or partial mac addresses',
               content: ['f4:90:ea', '0c:4d:e9:b1:05:f0'],
               proto: '',
-              updatefreq: '',
+              updatefreq: 0,
               counters: false,
               enabled: true,
               ensure: 'present'
@@ -296,7 +296,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
               description: 'Externally managed',
               content: [],
               proto: 'IPv4',
-              updatefreq: '',
+              updatefreq: 0,
               counters: true,
               enabled: true,
               ensure: 'present'
@@ -309,7 +309,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
               description: 'bogon networks (internal)',
               content: [],
               proto: '',
-              updatefreq: '',
+              updatefreq: 0,
               counters: false,
               enabled: true,
               ensure: 'present'
@@ -322,7 +322,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
               description: 'bogon networks IPv6 (internal)',
               content: [],
               proto: '',
-              updatefreq: '',
+              updatefreq: 0,
               counters: false,
               enabled: true,
               ensure: 'present'
@@ -335,7 +335,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
               description: 'abuse lockout table (internal)',
               content: [],
               proto: '',
-              updatefreq: '',
+              updatefreq: 0,
               counters: false,
               enabled: true,
               ensure: 'present'
@@ -348,7 +348,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
               description: 'overload table for rate limitting (internal)',
               content: [],
               proto: '',
-              updatefreq: '',
+              updatefreq: 0,
               counters: false,
               enabled: true,
               ensure: 'present'
@@ -370,7 +370,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
              description: 'bogon networks (internal)',
              content: [],
              proto: '',
-             updatefreq: '',
+             updatefreq: 0,
              counters: false,
              enabled: true,
              ensure: 'present'
@@ -383,7 +383,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
              description: 'bogon networks IPv6 (internal)',
              content: [],
              proto: '',
-             updatefreq: '',
+             updatefreq: 0,
              counters: false,
              enabled: true,
              ensure: 'present'
@@ -396,7 +396,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
              description: 'abuse lockout table (internal)',
              content: [],
              proto: '',
-             updatefreq: '',
+             updatefreq: 0,
              counters: false,
              enabled: true,
              ensure: 'present'
@@ -409,7 +409,7 @@ RSpec.describe Puppet::Provider::OpnsenseFirewallAlias::OpnsenseFirewallAlias do
              description: 'overload table for rate limitting (internal)',
              content: [],
              proto: '',
-             updatefreq: '',
+             updatefreq: 0,
              counters: false,
              enabled: true,
              ensure: 'present'

--- a/spec/unit/puppet/type/opnsense_firewall_alias_spec.rb
+++ b/spec/unit/puppet/type/opnsense_firewall_alias_spec.rb
@@ -59,9 +59,14 @@ RSpec.describe 'the opnsense_firewall_alias type' do
       expect(fw_alias[:proto]).to eq('')
     end
 
-    it 'accepts a updatefreq' do
+    it 'accepts a updatefreq as Float' do
       fw_alias[:updatefreq] = 0.5
       expect(fw_alias[:updatefreq]).to eq(0.5)
+    end
+
+    it 'accepts a updatefreq as Integer' do
+      fw_alias[:updatefreq] = 0
+      expect(fw_alias[:updatefreq]).to eq(0)
     end
 
     it 'accepts counters' do


### PR DESCRIPTION
Currently the module supports setting the alias attribute "updatefreq" to an empty string. However, this causes Puppet to alter the affected alias on every Puppet run:

```
Notice: /Stage[main]/Opnsense/Opnsense_firewall_alias[test_alias]/updatefreq: updatefreq changed 0.000000 to '' (corrective)
```

This happens because OPNsense expects only numeric values for "updatefreq":

https://github.com/opnsense/core/blob/6ca0e5b58f2049d09d9776fbce31cfd785dfeea9/src/opnsense/mvc/app/models/OPNsense/Firewall/Alias.xml#L70-L72

**Empty strings are still accepted, but are internally converted to `0` by OPNsense.**

So in order to solve this, this PR does two things:
- change the accepted data type from "Float" to "Numeric" (to align it with OPNsense' data type)
- change the default value from an empty string to `0` (the default value that is internally enforced by OPNsense)

This change is fully backwards-compatible, because it just sets the same value that is already enforced by OPNsense. However, an alias that was previously relying on the old default value (empty string) will see the following change on the next Puppet run:

```
Notice: /Stage[main]/Opnsense/Opnsense_firewall_alias[test_alias]/updatefreq: updatefreq changed '' to 0
```

All following Puppet runs will be completely silent. :)

(Side note: This behaviour seems to be newish, it probably started in OPNsense 22.7 and I'd assume that it is related to the phalcon/PHP upgrades. In older versions of OPNsense an emptry string for "updatefreq" was actually written to config.xml and not replaced with a `0`.)