### PR TITLE
better align default values with upstream OPNsense HAProxy plugin

### DIFF
--- a/lib/puppet/type/opnsense_haproxy_backend.rb
+++ b/lib/puppet/type/opnsense_haproxy_backend.rb
@@ -23,19 +23,19 @@ Puppet::ResourceApi.register_type(
       source                           => '',
       health_check_enabled             => true,
       health_check                     => '',
-      health_check_log_status          => true,
+      health_check_log_status          => false,
       check_interval                   => '',
       check_down_interval              => '',
       health_check_fall                => '',
       health_check_rise                => '',
       linked_mailer                    => '',
-      http2_enabled                    => true,
-      http2_enabled_nontls             => true,
+      http2_enabled                    => false,
+      http2_enabled_nontls             => false,
       ba_advertised_protocols          => ['h2', 'http11'],
       persistence                      => 'sticktable',
       persistence_cookiemode           => 'piggyback',
       persistence_cookiename           => 'SRVCOOKIE',
-      persistence_stripquotes          => true,
+      persistence_stripquotes          => false,
       stickiness_pattern               => 'sourceipv4',
       stickiness_data_types            => [],
       stickiness_expire                => '30m',
@@ -48,7 +48,7 @@ Puppet::ResourceApi.register_type(
       stickiness_http_err_rate_period  => '10s',
       stickiness_bytes_in_rate_period  => '1m',
       stickiness_bytes_out_rate_period => '1m',
-      basic_auth_enabled               => true,
+      basic_auth_enabled               => false,
       basic_auth_users                 => [],
       basic_auth_groups                => [],
       tuning_timeout_connect           => '',
@@ -57,9 +57,9 @@ Puppet::ResourceApi.register_type(
       tuning_retries                   => '',
       custom_options                   => '',
       tuning_defaultserver             => '',
-      tuning_noport                    => true,
+      tuning_noport                    => false,
       tuning_httpreuse                 => 'safe',
-      tuning_caching                   => true,
+      tuning_caching                   => false,
       linked_actions                   => [],
       linked_errorfiles                => [],
       ensure                           => 'present',
@@ -164,7 +164,7 @@ EOS
     health_check_log_status: {
       type: 'Boolean',
         desc: 'Enable to log health check status updates.',
-        default: true
+        default: false
     },
     check_interval: {
       type: 'Optional[String]',
@@ -189,12 +189,12 @@ EOS
     http2_enabled: {
       type: 'Boolean',
         desc: 'Enable support for end-to-end HTTP/2 communication.',
-        default: true
+        default: false
     },
     http2_enabled_nontls: {
       type: 'Boolean',
         desc: 'Enable support for HTTP/2 even if TLS is not enabled.',
-        default: true
+        default: false
     },
     ba_advertised_protocols: {
       type: 'Array[String]',
@@ -285,7 +285,7 @@ EOS
     basic_auth_enabled: {
       type: 'Boolean',
         desc: 'Enable HTTP basic authentication.',
-        default: true
+        default: false
     },
     basic_auth_users: {
       type: 'Array[String]',
@@ -324,7 +324,7 @@ EOS
     tuning_noport: {
       type: 'Boolean',
         desc: "Don't use port on server, use the same port as frontend receive.",
-        default: true
+        default: false
     },
     tuning_httpreuse: {
       type: "Enum['', 'never', 'safe', 'aggressive', 'always']",
@@ -334,7 +334,7 @@ EOS
     tuning_caching: {
       type: 'Boolean',
         desc: 'Enable caching of responses from this backend.',
-        default: true
+        default: false
     },
     linked_actions: {
       type: 'Array[String]',

--- a/lib/puppet/type/opnsense_haproxy_frontend.rb
+++ b/lib/puppet/type/opnsense_haproxy_frontend.rb
@@ -26,15 +26,15 @@ Puppet::ResourceApi.register_type(
       ssl_max_version                  => '',
       ssl_cipher_list                  => 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256',
       ssl_cipher_suites                => 'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256',
-      ssl_hsts_enabled                 => true,
-      ssl_hsts_include_sub_domains     => true,
-      ssl_hsts_preload                 => true,
+      ssl_hsts_enabled                 => false,
+      ssl_hsts_include_sub_domains     => false,
+      ssl_hsts_preload                 => false,
       ssl_hsts_max_age                 => '15768000',
-      ssl_client_auth_enabled          => true,
+      ssl_client_auth_enabled          => false,
       ssl_client_auth_verify           => 'required',
       ssl_client_auth_cas              => [],
       ssl_client_auth_crls             => [],
-      basic_auth_enabled               => true,
+      basic_auth_enabled               => false,
       basic_auth_users                 => [],
       basic_auth_groups                => [],
       tuning_max_connections           => '',
@@ -42,11 +42,11 @@ Puppet::ResourceApi.register_type(
       tuning_timeout_http_req          => '',
       tuning_timeout_http_keep_alive   => '',
       linked_cpu_affinity_rules        => [],
-      logging_dont_log_null            => true,
-      logging_dont_log_normal          => true,
-      logging_log_separate_errors      => true,
+      logging_dont_log_null            => false,
+      logging_dont_log_normal          => false,
+      logging_log_separate_errors      => false,
       logging_detailed_log             => true,
-      logging_socket_stats             => true,
+      logging_socket_stats             => false,
       stickiness_pattern               => '',
       stickiness_data_types            => [''],
       stickiness_expire                => '30m',
@@ -60,10 +60,10 @@ Puppet::ResourceApi.register_type(
       stickiness_http_err_rate_period  => '10s',
       stickiness_bytes_in_rate_period  => '1m',
       stickiness_bytes_out_rate_period => '1m',
-      http2_enabled                    => true,
-      http2_enabled_nontls             => true,
+      http2_enabled                    => false,
+      http2_enabled_nontls             => false,
       advertised_protocols             => ['h2', 'http11'],
-      forward_for                      => true,
+      forward_for                      => false,
       connection_behaviour             => 'http-keep-alive',
       custom_options                   => '',
       linked_actions                   => [],
@@ -136,7 +136,7 @@ EOS
     ssl_enabled: {
       type: 'Boolean',
         desc: 'Enable SSL offloading.',
-        default: true
+        default: false
     },
     ssl_certificates: {
       type: 'Array[String]',
@@ -156,7 +156,7 @@ EOS
     ssl_advanced_enabled: {
       type: 'Boolean',
         desc: 'Enable or disable advanced SSL settings.',
-        default: true
+        default: false
     },
     ssl_bind_options: {
       type: "Array[Enum[
@@ -194,12 +194,12 @@ EOS
     ssl_hsts_include_sub_domains: {
       type: 'Boolean',
         desc: 'Enable or disable if all present and future subdomains will be HTTPS.',
-        default: true
+        default: false
     },
     ssl_hsts_preload: {
       type: 'Boolean',
         desc: 'Enable if you like this domain to be included in the HSTS preload list.',
-        default: true
+        default: false
     },
     ssl_hsts_max_age: {
       type: 'String',
@@ -209,7 +209,7 @@ EOS
     ssl_client_auth_enabled: {
       type: 'Boolean',
         desc: 'Enable client certificate authentication.',
-        default: true
+        default: false
     },
     ssl_client_auth_verify: {
       type: "Enum['', 'none', 'optional', 'required']",
@@ -229,7 +229,7 @@ EOS
     basic_auth_enabled: {
       type: 'Boolean',
         desc: 'Enable HTTP Basic Authentication.',
-        default: true
+        default: false
     },
     basic_auth_users: {
       type: 'Array[String]',
@@ -269,27 +269,27 @@ EOS
     logging_dont_log_null: {
       type: 'Boolean',
         desc: 'Enable or disable logging of connections with no data.',
-        default: true
+        default: false
     },
     logging_dont_log_normal: {
       type: 'Boolean',
         desc: 'Enable or disable logging of normal, successful connections.',
-        default: true
+        default: false
     },
     logging_log_separate_errors: {
       type: 'Boolean',
         desc: 'Allow HAProxy to automatically raise log level for non-completely successful connections to aid debugging.',
-        default: true
+        default: false
     },
     logging_detailed_log: {
       type: 'Boolean',
         desc: 'Enable or disable verbose logging. Each log line turns into a much richer format.',
-        default: true
+        default: false
     },
     logging_socket_stats: {
       type: 'Boolean',
         desc: 'Enable or disable collecting & providing separate statistics for each socket.',
-        default: true
+        default: false
     },
     stickiness_pattern: {
       type: "Enum['', 'ipv4', 'ipv6', 'integer', 'string', 'binary']",
@@ -362,12 +362,12 @@ EOS
     http2_enabled: {
       type: 'Boolean',
         desc: 'Enable support for HTTP/2.',
-        default: true
+        default: false
     },
     http2_enabled_nontls: {
       type: 'Boolean',
         desc: 'Enable support for HTTP/2 even if TLS (SSL offloading) is not enabled.',
-        default: true
+        default: false
     },
     advertised_protocols: {
       type: "Array[Enum['', 'h2', 'http11', 'http10']]",
@@ -377,7 +377,7 @@ EOS
     forward_for: {
       type: 'Boolean',
         desc: 'Enable insertion of the X-Forwarded-For header to requests sent to servers.',
-        default: true
+        default: false
     },
     connection_behaviour: {
       type: "Enum['http-keep-alive', 'http-tunnel', 'httpclose', 'http-server-close', 'forceclose']",

--- a/lib/puppet/type/opnsense_haproxy_server.rb
+++ b/lib/puppet/type/opnsense_haproxy_server.rb
@@ -21,7 +21,7 @@ Puppet::ResourceApi.register_type(
         linked_resolver        => '',
         resolver_opts          => ['allow-dup-ip','ignore-weight','prevent-dup-ip'],
         resolve_prefer         => 'ipv4',
-        ssl                    => true,
+        ssl                    => false,
         ssl_verify             => true,
         ssl_ca                 => [],
         ssl_crl                => [],
@@ -124,7 +124,7 @@ EOS
     ssl: {
       type: 'Boolean',
         desc: 'Enable or disable SSL communication with this server.',
-        default: true
+        default: false
     },
     ssl_verify: {
       type: 'Boolean',


### PR DESCRIPTION
Currently several default values for frontends/backends deviate from the HAProxy plugin in OPNsense. As a result, some very rarely used features are enabled by default (SSL client authentication, basic authentication, enforcing HTTP2 for non-SSL connections, and so on).

This PR corrects these default values and replaces them with the same values that are used by the OPNsense HAProxy plugin.